### PR TITLE
Jessie sr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ yarn-debug.log*
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+

--- a/app/controllers/representatives_controller.rb
+++ b/app/controllers/representatives_controller.rb
@@ -4,4 +4,8 @@ class RepresentativesController < ApplicationController
   def index
     @representatives = Representative.all
   end
+
+  def show
+    @representative = Representative.find(params[:id])
+  end
 end

--- a/app/models/representative.rb
+++ b/app/models/representative.rb
@@ -3,25 +3,60 @@
 class Representative < ApplicationRecord
   has_many :news_items, dependent: :delete_all
 
-  def self.civic_api_to_representative_params(rep_info)
-    reps = []
-
-    rep_info.officials.each_with_index do |official, index|
-      ocdid_temp = ''
-      title_temp = ''
-
-      rep_info.offices.each do |office|
-        if office.official_indices.include? index
-          title_temp = office.name
-          ocdid_temp = office.division_id
-        end
-      end
-
-      rep = Representative.create!({ name: official.name, ocdid: ocdid_temp,
-          title: title_temp })
-      reps.push(rep)
+  class << self
+    def civic_api_to_representative_params(rep_info)
+      rep_info.officials.each_with_index.map do |official, index|
+        process_official(official, rep_info, index)
+      end.compact
     end
 
-    reps
+    private
+
+    def process_official(official, rep_info, index)
+      title, ocdid = extract_office_info(rep_info, index)
+      address = extract_address(official)
+      party = official.party if official.respond_to?(:party)
+      photo_url = official.photo_url if official.respond_to?(:photo_url)
+
+      update_or_create_representative({
+                                        official:  official,
+                                        title:     title,
+                                        ocdid:     ocdid,
+                                        address:   address,
+                                        party:     party,
+                                        photo_url: photo_url
+                                      })
+    end
+
+    def extract_office_info(rep_info, index)
+      office = rep_info.offices.find { |o| o.official_indices.include?(index) }
+      [office&.name, office&.division_id]
+    end
+
+    def extract_address(official)
+      address = official.address&.first
+      {
+        street: address&.line1,
+        city:   address&.city,
+        state:  address&.state,
+        zip:    address&.zip
+      }
+    end
+
+    def update_or_create_representative(params)
+      rep = Representative.find_or_initialize_by(name: params[:official].name, ocdid: params[:ocdid])
+      rep.assign_attributes({
+                              title:     params[:title],
+                              street:    params[:address][:street],
+                              city:      params[:address][:city],
+                              state:     params[:address][:state],
+                              zip:       params[:address][:zip],
+                              party:     params[:party],
+                              photo_url: params[:photo_url]
+                            })
+      # Save the record only if it's a new record or if any attribute has changed
+      rep.save! if rep.new_record? || rep.changed?
+      rep
+    end
   end
 end

--- a/app/views/representatives/search.html.haml
+++ b/app/views/representatives/search.html.haml
@@ -12,7 +12,8 @@
                     %tbody
                         - @representatives.each_with_index do |rep, _index|
                             %tr
-                                %td= rep.name
+                                %td
+                                    = link_to rep.name, representative_path(rep.id)
                                 %td= rep.title
                                 %td
                                     = link_to representative_news_items_path(rep.id), class: 'btn btn-primary' do

--- a/app/views/representatives/show.html.erb
+++ b/app/views/representatives/show.html.erb
@@ -1,0 +1,5 @@
+<h1><%= @representative.name %></h1>
+<p>Office: <%= @representative.title %></p>
+<p>Address: <%= [@representative.street, @representative.city, @representative.state, @representative.zip].compact.join(', ') %></p>
+<p>Party: <%= @representative.party %></p>
+<%= image_tag @representative.photo_url if @representative.photo_url %>

--- a/db/migrate/20200728065604_add_columns_to_representatives.rb
+++ b/db/migrate/20200728065604_add_columns_to_representatives.rb
@@ -4,5 +4,11 @@ class AddColumnsToRepresentatives < ActiveRecord::Migration[5.2]
   def change
     add_column :representatives, :ocdid, :string
     add_column :representatives, :title, :string
+    add_column :representatives, :street, :string
+    add_column :representatives, :city, :string
+    add_column :representatives, :state, :string
+    add_column :representatives, :zip, :string
+    add_column :representatives, :party, :string
+    add_column :representatives, :photo_url, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,6 +49,12 @@ ActiveRecord::Schema.define(version: 2020_07_28_065604) do
     t.datetime "updated_at", null: false
     t.string "ocdid"
     t.string "title"
+    t.string "street"
+    t.string "city"
+    t.string "state"
+    t.string "zip"
+    t.string "party"
+    t.string "photo_url"
   end
 
   create_table "states", force: :cascade do |t|

--- a/features/refactor_representative.feature
+++ b/features/refactor_representative.feature
@@ -1,0 +1,14 @@
+Feature: Refactor Representative Import
+  In order to avoid creating duplicate representatives in the database
+  As a developer
+  I want to refactor the civic_api_to_representative_params method
+
+  Scenario: Import a new representative
+    Given a representative named "John Doe" does not exist in the database
+    When I import the representative "John Doe"
+    Then I should see "John Doe" in the database
+
+  Scenario: Avoid duplicate representatives
+    Given a representative named "John Doe" already exists in the database
+    When I import the representative "John Doe"
+    Then I should see only one "John Doe" in the database

--- a/features/step_definitions/representative_steps.rb
+++ b/features/step_definitions/representative_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^a representative named "([^"]*)" does not exist in the database$/) do |name|
   Representative.where(name: name).destroy_all
 end
@@ -10,15 +12,15 @@ When(/^I import the representative "([^"]*)"$/) do |name|
   rep_info = OpenStruct.new(
     officials: [
       OpenStruct.new(
-        name: name,
+        name: name
         # ... Add other properties as needed
       )
     ],
-    offices: [
+    offices:   [
       # ... Add offices data as needed
     ]
   )
-  
+
   Representative.civic_api_to_representative_params(rep_info)
 end
 

--- a/features/step_definitions/representative_steps.rb
+++ b/features/step_definitions/representative_steps.rb
@@ -1,0 +1,31 @@
+Given(/^a representative named "([^"]*)" does not exist in the database$/) do |name|
+  Representative.where(name: name).destroy_all
+end
+
+Given(/^a representative named "([^"]*)" already exists in the database$/) do |name|
+  Representative.find_or_create_by!(name: name)
+end
+
+When(/^I import the representative "([^"]*)"$/) do |name|
+  rep_info = OpenStruct.new(
+    officials: [
+      OpenStruct.new(
+        name: name,
+        # ... Add other properties as needed
+      )
+    ],
+    offices: [
+      # ... Add offices data as needed
+    ]
+  )
+  
+  Representative.civic_api_to_representative_params(rep_info)
+end
+
+Then(/^I should see "([^"]*)" in the database$/) do |name|
+  expect(Representative.find_by(name: name)).not_to be_nil
+end
+
+Then(/^I should see only one "([^"]*)" in the database$/) do |name|
+  expect(Representative.where(name: name).count).to eq(1)
+end

--- a/spec/models/representative_spec.rb
+++ b/spec/models/representative_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spec_helper'
+
+RSpec.describe Representative, type: :model do
+  describe '.civic_api_to_representative_params' do
+    # Mock the rep_info structure
+    let(:rep_info) do
+      OpenStruct.new(
+        officials: [
+          OpenStruct.new(
+            name:      'John Doe',
+            title:     'Mayor', # Assuming title and ocdid are provided from offices data
+            ocdid:     'ocd-division/country:us/state:anystate/place:anytown',
+            party:     'Independent',
+            photo_url: 'http://example.com/john_doe.jpg',
+            address:   [OpenStruct.new(
+              line1: '123 Main St',
+              city:  'Anytown',
+              state: 'Anystate',
+              zip:   '12345'
+            )]
+          )
+          # ... Add more officials as needed
+        ],
+        offices:   [
+          OpenStruct.new(
+            name:             'Mayor',
+            division_id:      'ocd-division/country:us/state:anystate/place:anytown',
+            official_indices: [0]
+          )
+          # ... Add more offices as needed
+        ]
+      )
+    end
+
+    context 'when the representative does not exist' do
+      it 'creates a new representative' do
+        expect do
+          described_class.civic_api_to_representative_params(rep_info)
+        end.to change(described_class, :count).by(1)
+      end
+    end
+
+    context 'when the representative already exists' do
+      let!(:existing_rep) do
+        described_class.create!(
+          name:      'John Doe',
+          ocdid:     'ocd-division/country:us/state:anystate/place:anytown',
+          title:     'Old Title',
+          party:     'Old Party',
+          photo_url: 'http://example.com/old_photo.jpg',
+          street:    'Old Street',
+          city:      'Old City',
+          state:     'Old State',
+          zip:       'Old Zip'
+        )
+      end
+
+      before do
+        described_class.civic_api_to_representative_params(rep_info)
+        existing_rep.reload
+      end
+
+      it 'does not create a duplicate representative' do
+        expect(described_class.count).to eq(1)
+      end
+
+      it 'updates the representative title' do
+        expect(existing_rep.title).to eq('Mayor')
+      end
+
+      it 'updates the representative party' do
+        expect(existing_rep.party).to eq('Independent')
+      end
+
+      it 'updates the representative photo_url' do
+        expect(existing_rep.photo_url).to eq('http://example.com/john_doe.jpg')
+      end
+
+      it 'updates the representative street' do
+        expect(existing_rep.street).to eq('123 Main St')
+      end
+
+      it 'updates the representative city' do
+        expect(existing_rep.city).to eq('Anytown')
+      end
+
+      it 'updates the representative state' do
+        expect(existing_rep.state).to eq('Anystate')
+      end
+
+      it 'updates the representative zip' do
+        expect(existing_rep.zip).to eq('12345')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Done with part 1 (hopefully) with the following changes:

1. Added rspec tests and cucumber tests for part 1: created spec/models/representative_spec.rb for rspec tests and  features/refactor_representatives.feature, features/step_definitions/representative_steps.rb for cucumber tests
2. Modified civic_api_to_representative_params in app/models/representative.rb so that it passed all the rubocop, lint, haml-lint, rspec and cucumber tests

As for part 2, since I’ve attempted it, the following files are also changed:

1. civic_api_to_representative_params in app/models/representative.rb has already included contact address (street, city, state, zip), political party, and a photo of the representative
2. db/migrate/20200728065604_add_columns_to_representatives.rb has also been updated to include the above additional information in the database
3. views/representatives/show.html.erb has been created, so does the show method in representative_controller.rb
4. The link to view the profile of each representative has been added in app/views/representatives/search.html.haml
